### PR TITLE
Update allowlists

### DIFF
--- a/Facebook_Allowlist.txt
+++ b/Facebook_Allowlist.txt
@@ -9,3 +9,4 @@
 @@||edge-mqtt.facebook.com^$important
 @@||external.xx.fbcdn.net^$important
 @@||scontent.xx.fbcdn.net^$important
+@@||messenger.com^$important

--- a/Lennox_and_Ring_Allowlist.txt
+++ b/Lennox_and_Ring_Allowlist.txt
@@ -7,3 +7,4 @@
 @@||events.launchdarkly.com^
 @@||click.redditmail.com^
 @@||rewards.bing.com^$important
+@@||app.ring.com^


### PR DESCRIPTION
## Summary
- whitelist Messenger for Facebook functionality
- allow the app.ring.com domain for Ring devices

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843178c00ec83239d8720bf4e9ff16f