### PR TITLE
Add humorous main page and README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ Below is a brief description of each list provided in this repository and what i
 - **Google_Gemini_Blocklist.txt** – Blocks Google Gemini (formerly Bard) AI endpoints and related services.
 - **Meta_Allowlist.txt** – Whitelist rules to permit Facebook domains when using these blocklists.
 - **Home_Automation_Allowlist.txt** – Whitelist rules to keep Lennox, Ring, Nest, and TP-Link services accessible.
+
+## Using These Lists
+Copy the raw text of any blocklist into your ad blocker of choice. Most folks just paste it into AdGuard Home, Pi-hole, or uBlock Origin. Update regularly—Microsoft has a habit of spawning new endpoints like rabbits.
+
+## Why So Serious?
+Sure, the repo name is a bit cheeky, but the goal is simple: reclaim a little privacy. If our lists help you out and make you chuckle, that's a win-win.
+
+For a friendly overview, check out [index.md](./index.md).

--- a/index.md
+++ b/index.md
@@ -1,0 +1,7 @@
+# Welcome to Piss-off-Microsoft
+
+Ever wished you could tell Microsoft and Google to pipe down? You're in the right place. These blocklists are maintained by folks who enjoy a quiet network and the occasional laugh at Clippy's expense.
+
+Use them with your favorite DNS blocker or ad-blocker and enjoy a little peace of mind. If something breaks, open an issue or send a PR—sarcastic comments welcome.
+
+Happy blocking!


### PR DESCRIPTION
## Summary
- add `index.md` as a small humorous landing page
- expand README with usage instructions and a light-hearted note

## Testing
- `git show -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6843339f9ef883238b5fc93c7a9bcde5