### PR TITLE
Update blocklists and add release version

### DIFF
--- a/Adult_Content_Blocklist.txt
+++ b/Adult_Content_Blocklist.txt
@@ -1,8 +1,8 @@
 ! Title: Adult Content Domains Blocklist
 ! Description: Keeps the risque stuff off your network filter.
-! Version: 1.0.0
+! Version: 1.1.0
 ! License: Public Domain / CC0
-! Last updated: 2025-06-07
+! Last updated: 2025-06-08
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, etc.
 !
 ||pornhub.com^
@@ -29,3 +29,4 @@
 ||xlovecam.com^
 ||wifelovers.com^
 ||worldsbestcams.com^
+||spankwire.com^

--- a/General_Blocking_Rules.txt
+++ b/General_Blocking_Rules.txt
@@ -1,8 +1,8 @@
 ! Title: General Blocking Rules
 ! Description: Sweeps away generic trackers nobody asked for.
-! Version: 1.0.0
+! Version: 1.1.0
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-07
+! Last updated: 2025-06-08
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, and other adblock-compatible systems.
 
 ||logs.netflix.com^
@@ -43,3 +43,4 @@
 ||px.ads.linkedin.com^
 ||stats.wp.com^
 ||pixel.wp.com^
+||ads.yahoo.com^

--- a/Google_Gemini_Blocklist.txt
+++ b/Google_Gemini_Blocklist.txt
@@ -2,7 +2,7 @@
 ! Description: Keeps Gemini from whispering AI secrets behind your back.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-07
+! Last updated: 2025-06-08
 ! Author: talonric332
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, and any DNS/adblock filter system.
 ! Note: This list blocks AI features from Google for all clients. If you only want to block for VPN clients, use a version with $client=127.0.0.1.
@@ -27,3 +27,4 @@
 ||gemini.googleapis.com^
 ||gemini-pa.googleapis.com^
 ||bard.googleapis.com^
+||gemini.googleusercontent.com^

--- a/Home_Automation_Allowlist.txt
+++ b/Home_Automation_Allowlist.txt
@@ -2,7 +2,7 @@
 ! Description: So your smart gadgets keep chatting while everything else hushes up.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-07
+! Last updated: 2025-06-08
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, etc.
 
 @@||api.ring.com^
@@ -19,3 +19,4 @@
 @@||app.ring.com^
 @@||nest.com^
 @@||dropcam.com^
+@@||ecobee.com^

--- a/Meta_Allowlist.txt
+++ b/Meta_Allowlist.txt
@@ -2,7 +2,7 @@
 ! Description: Because sometimes you really do need to check those cat photos.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-07
+! Last updated: 2025-06-08
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, etc.
 
 @@||facebook.com^$important
@@ -17,3 +17,4 @@
 @@||external.xx.fbcdn.net^$important
 @@||scontent.xx.fbcdn.net^$important
 @@||messenger.com^$important
+@@||instagram.com^$important

--- a/Microsoft_Tracking_Blocklist.txt
+++ b/Microsoft_Tracking_Blocklist.txt
@@ -2,7 +2,7 @@
 ! Description: Tells Copilot, Bing AI, and the rest of Microsoft's snoops to take a hike.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-07
+! Last updated: 2025-06-08
 ! Author: talonric332
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, and any DNS/adblock filter system.
 ! Note: This version blocks for all clients. If you're using Tailscale/VPNs, use a separate list with $client=127.0.0.1 rules.
@@ -64,3 +64,5 @@
 ||ads1.msads.net^
 ||ads2.msads.net^
 ||adnxs.com^
+||loop.microsoft.com^
+||copilotassets.azureedge.net^

--- a/Mobile_Game_Ads_Blocklist.txt
+++ b/Mobile_Game_Ads_Blocklist.txt
@@ -2,7 +2,7 @@
 ! Description: Boots out mobile game ad networks so you can actually enjoy your high score.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-07
+! Last updated: 2025-06-08
 ! Author: talonric332
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, and other adblock-compatible systems.
 
@@ -48,3 +48,4 @@
 ||ssp-events.chartboost.com^
 ||t.chartboost.com^
 ||v2.chartboost.com^
+||ads.tapdaq.com^

--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ Use the raw links above to grab any list and import it into your ad blocker of c
 Sure, the repo name is a bit cheeky, but the goal is simple: reclaim a little privacy. If our lists help you out and make you chuckle, that's a win-win.
 
 For a friendly overview, check out [index.md](./index.md).
+
+## Releases
+Current version: **v1.1.0**
+These blocklists are updated regularly. Grab the latest release from the GitHub releases page.

--- a/Samsung_Tracker_Blocklist_Cleaned.txt
+++ b/Samsung_Tracker_Blocklist_Cleaned.txt
@@ -2,7 +2,7 @@
 ! Description: Muzzles Samsung's built-in snitchware.
 ! Version: 2025.0530.2356.11
 ! Homepage: https://github.com/hagezi/dns-blocklists
-! Last updated: 2025-05-30 23:56 UTC
+! Last updated: 2025-06-08 00:00 UTC
 !
 ! Converted from HaGeZi native.samsung.txt
 ||samsung-com.112.2o7.net^
@@ -259,3 +259,4 @@
 ||samsungusa.api.useinsider.com^
 ||samsungvn.api.useinsider.com^
 ||h4g3z1-native.samsung.web.app^
+||metrics.samsungapps.com^

--- a/Slimmed_Microsoft_Blocklist.txt
+++ b/Slimmed_Microsoft_Blocklist.txt
@@ -2,7 +2,7 @@
 ! Description: Keeps Copilot and Bing in check while letting Excel do its thing.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-07
+! Last updated: 2025-06-08
 ! Author: talonric332
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, etc.
 
@@ -41,3 +41,5 @@
 @@||settings.office.com^
 @@||login.microsoftonline.com^
 @@||outlook.office365.com^
+||copilot.microsoft.com^
+||copilot.microsoft365.com^


### PR DESCRIPTION
## Summary
- refresh blocklist files with new domains and dates
- bump general and adult lists to version 1.1.0
- add an Instagram allow rule
- add a simple Releases section with version number

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6843507ad16883238802c511d47f5027