### PR TITLE
Refresh blocklists with new domains

### DIFF
--- a/Adult_Content_Blocklist.txt
+++ b/Adult_Content_Blocklist.txt
@@ -2,7 +2,7 @@
 ! Description: Keeps the risque stuff off your network filter.
 ! Version: 1.2.0
 ! License: Public Domain / CC0
-! Last updated: 2025-06-06
+! Last updated: 2025-06-07
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, etc.
 !
 ||pornhub.com^

--- a/Gaming_Allowlist.txt
+++ b/Gaming_Allowlist.txt
@@ -2,7 +2,7 @@
 ! Description: Keeps Roblox, Minecraft, GTA Online and other games running without a hitch.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-06
+! Last updated: 2025-06-07
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, etc.
 
 @@||roblox.com^

--- a/General_Blocking_Rules.txt
+++ b/General_Blocking_Rules.txt
@@ -64,3 +64,8 @@
 ||log.byteoversea.com^
 ||mon.byteoversea.com^
 ||abtest-va-tiktok.byteoversea.com^
+||api.mixpanel.com^
+||decide.mixpanel.com^
+||switchboard.mixpanel.com^
+||browser-intake-datadoghq.com^
+||logs.datadoghq.com^

--- a/Google_Gemini_Blocklist.txt
+++ b/Google_Gemini_Blocklist.txt
@@ -2,7 +2,7 @@
 ! Description: Keeps Gemini from whispering AI secrets behind your back.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-06
+! Last updated: 2025-06-07
 ! Author: talonric332
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, and any DNS/adblock filter system.
 ! Note: This list blocks AI features from Google for all clients. If you only want to block for VPN clients, use a version with $client=127.0.0.1.

--- a/Home_Automation_Allowlist.txt
+++ b/Home_Automation_Allowlist.txt
@@ -2,7 +2,7 @@
 ! Description: So your smart gadgets keep chatting while everything else hushes up.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-06
+! Last updated: 2025-06-07
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, etc.
 
 @@||api.ring.com^

--- a/Meta_Allowlist.txt
+++ b/Meta_Allowlist.txt
@@ -2,7 +2,7 @@
 ! Description: Because sometimes you really do need to check those cat photos.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-06
+! Last updated: 2025-06-07
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, etc.
 
 @@||facebook.com^$important

--- a/Microsoft_Tracking_Blocklist.txt
+++ b/Microsoft_Tracking_Blocklist.txt
@@ -2,7 +2,7 @@
 ! Description: Tells Copilot, Bing AI, and the rest of Microsoft's snoops to take a hike.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-06
+! Last updated: 2025-06-07
 ! Author: talonric332
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, and any DNS/adblock filter system.
 ! Note: This version blocks for all clients. If you're using Tailscale/VPNs, use a separate list with $client=127.0.0.1 rules.
@@ -36,6 +36,20 @@
 ||ads.microsoft.com^
 ||ads.msn.com^
 ||adsyndication.msn.com^
+||g.msn.com^
+||c.msn.com^
+||edge.msn.com^
+||ads1.msn.com^
+||a.ads1.msn.com^
+||b.ads1.msn.com^
+||ads2.msn.com^
+||a.ads2.msn.com^
+||b.ads2.msn.com^
+||mobileads.msn.com^
+||rads.msn.com^
+||srtb.msn.com^
+||ads.bing.com^
+||adserver.bing.com^
 ||analytics.live.com^
 ||analytics.msn.com^
 ||applicationinsights.azure.com^

--- a/Mobile_Game_Ads_Blocklist.txt
+++ b/Mobile_Game_Ads_Blocklist.txt
@@ -2,7 +2,7 @@
 ! Description: Boots out mobile game ad networks so you can actually enjoy your high score.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-06
+! Last updated: 2025-06-07
 ! Author: talonric332
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, and other adblock-compatible systems.
 

--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ Sure, the repo name is a bit cheeky, but the goal is simple: reclaim a little pr
 For a friendly overview, check out [index.md](./index.md).
 
 ## Releases
-Current version: **v1.2.0**
+Current version: **v1.2.1**
 These blocklists are updated regularly. Grab the latest release from the GitHub releases page.

--- a/Samsung_Tracker_Blocklist_Cleaned.txt
+++ b/Samsung_Tracker_Blocklist_Cleaned.txt
@@ -2,7 +2,7 @@
 ! Description: Muzzles Samsung's built-in snitchware.
 ! Version: 2025.0530.2356.11
 ! Homepage: https://github.com/hagezi/dns-blocklists
-! Last updated: 2025-06-06 00:00 UTC
+! Last updated: 2025-06-07 00:00 UTC
 !
 ! Converted from HaGeZi native.samsung.txt
 ||samsung-com.112.2o7.net^

--- a/Slimmed_Microsoft_Blocklist.txt
+++ b/Slimmed_Microsoft_Blocklist.txt
@@ -2,7 +2,7 @@
 ! Description: Keeps Copilot and Bing in check while letting Excel do its thing.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-06
+! Last updated: 2025-06-07
 ! Author: talonric332
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, etc.
 
@@ -25,6 +25,10 @@
 ||prism.app.microsoft.com^
 ||ads.msn.com^
 ||adsyndication.msn.com^
+||g.msn.com^
+||edge.msn.com^
+||ads.bing.com^
+||adserver.bing.com^
 ||analytics.msn.com^
 ||telemetry.appex.bing.net^
 ||bingads.microsoft.com^


### PR DESCRIPTION
## Summary
- add Bing/MSN tracker domains to Microsoft lists
- extend General Blocking rules with Mixpanel and Datadog
- refresh last updated dates across lists
- bump README to v1.2.1

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6844c1ea5b108323ba8fe20dada21779