### PR TITLE
Add daily list update automation

### DIFF
--- a/.github/workflows/update-lists.yml
+++ b/.github/workflows/update-lists.yml
@@ -1,0 +1,31 @@
+name: Update Blocklists
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install pyyaml requests
+      - name: Update lists
+        run: python scripts/update_lists.py
+      - name: Commit changes
+        run: |
+          git config user.name 'github-actions'
+          git config user.email 'github-actions@users.noreply.github.com'
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -m 'Automated list update'
+            git push
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -46,3 +46,6 @@ For a friendly overview, check out [index.md](./index.md).
 ## Releases
 Current version: **v1.2.1**
 These blocklists are updated regularly. Grab the latest release from the GitHub releases page.
+
+## Automation
+These lists update daily thanks to a GitHub Actions workflow. The script in `scripts/update_lists.py` pulls fresh sources and removes anything allowed in our allowlists. You can trigger it manually from the Actions tab if needed.

--- a/scripts/update_lists.py
+++ b/scripts/update_lists.py
@@ -1,0 +1,101 @@
+import datetime
+import yaml
+import requests
+import re
+from pathlib import Path
+
+RE_DOMAIN = re.compile(r"^[|@]*\|\|([^/^$]*)")
+
+BLOCKLIST_SUFFIX = "_Blocklist.txt"
+ALLOWLIST_SUFFIX = "_Allowlist.txt"
+
+
+def parse_domains(text):
+    domains = set()
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("!") or line.startswith("#"):
+            continue
+        if line.startswith("@@||"):
+            domain = RE_DOMAIN.match(line)
+            if domain:
+                domains.add(domain.group(1))
+        elif line.startswith("||"):
+            domain = RE_DOMAIN.match(line)
+            if domain:
+                domains.add(domain.group(1))
+        elif line.startswith("0.0.0.0") or line.startswith("127.0.0.1"):
+            parts = line.split()
+            if len(parts) >= 2:
+                domains.add(parts[1])
+    return domains
+
+
+def extract_header(text):
+    lines = []
+    for line in text.splitlines():
+        if line.startswith("!") or not line.strip():
+            lines.append(line)
+        else:
+            break
+    return lines
+
+
+def update_list(path, sources, allow_domains):
+    current_text = Path(path).read_text()
+    header = extract_header(current_text)
+
+    domains = parse_domains(current_text)
+
+    for url in sources:
+        try:
+            r = requests.get(url, timeout=30)
+            if r.status_code == 200:
+                domains.update(parse_domains(r.text))
+        except Exception as e:
+            print(f"Failed fetching {url}: {e}")
+
+    # remove allowlist domains
+    domains.difference_update(allow_domains)
+
+    # sort domains
+    sorted_domains = sorted(domains)
+
+    # update last updated line
+    today = datetime.date.today().isoformat()
+    new_header = []
+    last_updated_line_found = False
+    for line in header:
+        if line.startswith("! Last updated:"):
+            new_header.append(f"! Last updated: {today}")
+            last_updated_line_found = True
+        else:
+            new_header.append(line)
+    if not last_updated_line_found:
+        new_header.append(f"! Last updated: {today}")
+
+    content = "\n".join(new_header) + "\n" + "\n".join(f"||{d}^" for d in sorted_domains) + "\n"
+    Path(path).write_text(content)
+
+
+def main():
+    cfg_path = Path("sources.yml")
+    if not cfg_path.exists():
+        print("sources.yml not found; nothing to do")
+        return
+    cfg = yaml.safe_load(cfg_path.read_text())
+
+    allow_domains = set()
+    for allow_file in Path('.').glob(f'*{ALLOWLIST_SUFFIX}'):
+        allow_domains.update(parse_domains(Path(allow_file).read_text()))
+
+    for block_file, urls in cfg.items():
+        if not Path(block_file).exists():
+            continue
+        if not isinstance(urls, list):
+            urls = [urls]
+        update_list(block_file, urls, allow_domains)
+
+
+if __name__ == '__main__':
+    main()

--- a/sources.yml
+++ b/sources.yml
@@ -1,0 +1,14 @@
+Microsoft_Tracking_Blocklist.txt:
+  - https://raw.githubusercontent.com/Roosen12/Invoke-DOS/main/lists/microsoft/list
+Slimmed_Microsoft_Blocklist.txt:
+  - https://raw.githubusercontent.com/Roosen12/Invoke-DOS/main/lists/microsoft/list
+General_Blocking_Rules.txt:
+  - https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
+Samsung_Tracker_Blocklist_Cleaned.txt:
+  - https://raw.githubusercontent.com/hagezi/dns-blocklists/main/native/samsung.txt
+Mobile_Game_Ads_Blocklist.txt:
+  - https://raw.githubusercontent.com/o0HalfLife0o/list/master/adservers.txt
+Adult_Content_Blocklist.txt:
+  - https://raw.githubusercontent.com/blocklistproject/Lists/master/adult.txt
+Google_Gemini_Blocklist.txt:
+  - https://raw.githubusercontent.com/blocklistproject/Lists/master/tracking.txt


### PR DESCRIPTION
## Summary
- add GitHub Action to update blocklists every day
- create `update_lists.py` script for merging lists without conflicting allow rules
- document automation in README
- provide `sources.yml` with upstream list URLs

## Testing
- `python scripts/update_lists.py` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml requests`
- `python scripts/update_lists.py`

------
https://chatgpt.com/codex/tasks/task_e_684a1986593883238c9f7a3c26da2c91