### PR TITLE
Add more Xbox blocking domains

### DIFF
--- a/General_Blocking_Rules.txt
+++ b/General_Blocking_Rules.txt
@@ -53,6 +53,14 @@
 ||c.xbox.com^
 ||o.xbox.com^
 ||microsoftxbox.112.2o7.net^
+||ads.xbox-scene.com^
+||xbox-ms-store-debug.com^
+||xbox360emulator.com^
+||www.xbox360emulator.com^
+||xboxgamerguide.com^
+||www.xboxgamerguide.com^
+||xbox.ign.us.intellitxt.com^
+||xbox360.ign.us.intellitxt.com^
 ||rad.msn.com^
 ||at.atwola.com^
 ||nw-umwatson.events.data.microsoft.com^

--- a/Microsoft_Tracking_Blocklist.txt
+++ b/Microsoft_Tracking_Blocklist.txt
@@ -77,6 +77,14 @@
 ||c.xbox.com^
 ||o.xbox.com^
 ||microsoftxbox.112.2o7.net^
+||ads.xbox-scene.com^
+||xbox-ms-store-debug.com^
+||xbox360emulator.com^
+||www.xbox360emulator.com^
+||xboxgamerguide.com^
+||www.xboxgamerguide.com^
+||xbox.ign.us.intellitxt.com^
+||xbox360.ign.us.intellitxt.com^
 ||rad.msn.com^
 ||at.atwola.com^
 ||nw-umwatson.events.data.microsoft.com^

--- a/Slimmed_Microsoft_Blocklist.txt
+++ b/Slimmed_Microsoft_Blocklist.txt
@@ -45,6 +45,14 @@
 ||c.xbox.com^
 ||o.xbox.com^
 ||microsoftxbox.112.2o7.net^
+||ads.xbox-scene.com^
+||xbox-ms-store-debug.com^
+||xbox360emulator.com^
+||www.xbox360emulator.com^
+||xboxgamerguide.com^
+||www.xboxgamerguide.com^
+||xbox.ign.us.intellitxt.com^
+||xbox360.ign.us.intellitxt.com^
 ||rad.msn.com^
 ||at.atwola.com^
 ||nw-umwatson.events.data.microsoft.com^


### PR DESCRIPTION
## Summary
- expand Xbox coverage by blocking xbox-scene, xboxgamerguide, and other domains

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_685742cff9288323a30827e370f2b883