### PR TITLE
Update blocklists with new domains

### DIFF
--- a/Adult_Content_Blocklist.txt
+++ b/Adult_Content_Blocklist.txt
@@ -2,7 +2,7 @@
 ! Description: Blocks commonly known adult and pornographic domains.
 ! Version: 1.2.1
 ! License: Public Domain / CC0
-! Last updated: 2025-06-21
+! Last updated: 2025-06-25
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, etc.
 !
 ||bangbros.com^

--- a/Advertising_Network_Blocklist.txt
+++ b/Advertising_Network_Blocklist.txt
@@ -2,7 +2,7 @@
 ! Description: Blocks Google ad servers and other major advertising networks.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-21
+! Last updated: 2025-06-25
 ! Author: talonric332
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, and other adblock-compatible systems.
 

--- a/Gaming_Allowlist.txt
+++ b/Gaming_Allowlist.txt
@@ -2,7 +2,7 @@
 ! Description: Allows network access required by major gaming platforms.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-21
+! Last updated: 2025-06-25
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, etc.
 
 @@||roblox.com^

--- a/General_Allowlist.txt
+++ b/General_Allowlist.txt
@@ -2,7 +2,7 @@
 ! Description: Allows common services including Amazon domains removed from the block lists.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-21
+! Last updated: 2025-06-25
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, etc.
 
 @@||amazonaws.com^

--- a/General_Blocking_Rules.txt
+++ b/General_Blocking_Rules.txt
@@ -2,7 +2,7 @@
 ! Description: Generic tracker domains aggregated from multiple sources.
 ! Version: 1.2.5
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-21
+! Last updated: 2025-06-25
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, and other adblock-compatible systems.
 ||logs.netflix.com^
 ||www.google-analytics.com^

--- a/Google_Gemini_Blocklist.txt
+++ b/Google_Gemini_Blocklist.txt
@@ -2,7 +2,7 @@
 ! Description: Blocks Google Gemini (formerly Bard), generative AI endpoints, and assistant APIs used for AI features.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-21
+! Last updated: 2025-06-25
 ! Author: talonric332
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, and any DNS/adblock filter system.
 ! Note: This list blocks AI features from Google for all clients. If you only want to block for VPN clients, use a version with $client=127.0.0.1.

--- a/Home_Automation_Allowlist.txt
+++ b/Home_Automation_Allowlist.txt
@@ -2,7 +2,7 @@
 ! Description: Allows connectivity for common smart home services.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-21
+! Last updated: 2025-06-25
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, etc.
 
 @@||api.ring.com^

--- a/Meta_Allowlist.txt
+++ b/Meta_Allowlist.txt
@@ -2,7 +2,7 @@
 ! Description: Allows access to Facebook, Instagram and other Meta services.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-21
+! Last updated: 2025-06-25
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, etc.
 
 @@||facebook.com^$important

--- a/Microsoft_Tracking_Blocklist.txt
+++ b/Microsoft_Tracking_Blocklist.txt
@@ -2,7 +2,7 @@
 ! Description: Blocks Microsoft telemetry, Copilot, Bing advertising and related domains.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-21
+! Last updated: 2025-06-25
 ! Author: talonric332
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, and any DNS/adblock filter system.
 ! Note: This version blocks for all clients. If you're using Tailscale/VPNs, use a separate list with $client=127.0.0.1 rules.
@@ -19,9 +19,13 @@
 ||ads2.msn.com^
 ||adserver.bing.com^
 ||adsyndication.msn.com^
+||agent.microsoft.com^
+||alerts.microsoft.com^
 ||alpha.telemetry.microsoft.com^
 ||analytics.live.com^
 ||analytics.msn.com^
+||answers-test.microsoft.com^
+||answers.microsoft.com^
 ||api.bing.com^
 ||applicationinsights.azure.com^
 ||arc-ring.msedge.net^

--- a/Mobile_Game_Ads_Blocklist.txt
+++ b/Mobile_Game_Ads_Blocklist.txt
@@ -2,7 +2,7 @@
 ! Description: Blocks advertising networks commonly bundled with mobile games.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-21
+! Last updated: 2025-06-25
 ! Author: talonric332
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, and other adblock-compatible systems.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,6 @@ affiliation with Microsoft, Google or any other company—just a shared desire t
 mute intrusive telemetry.
 
 ## Releases
-Current version: **v1.2.9**
+Current version: **v1.3.0**
 These blocklists are updated regularly. Grab the latest release from the GitHub releases page.
 

--- a/Samsung_Tracker_Blocklist_Cleaned.txt
+++ b/Samsung_Tracker_Blocklist_Cleaned.txt
@@ -2,7 +2,7 @@
 ! Description: Blocks telemetry services built into Samsung devices.
 ! Version: 2025.0616.1258.12
 ! Homepage: https://github.com/hagezi/dns-blocklists
-! Last updated: 2025-06-21
+! Last updated: 2025-06-25
 ! Converted from HaGeZi native.samsung.txt
 ||samsung-com.112.2o7.net^
 ||metric.account-samsung.com^

--- a/Slimmed_Microsoft_Blocklist.txt
+++ b/Slimmed_Microsoft_Blocklist.txt
@@ -2,7 +2,7 @@
 ! Description: Minimal blocklist to cut Microsoft telemetry without affecting key apps.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-21
+! Last updated: 2025-06-25
 ! Author: talonric332
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, etc.
 
@@ -25,7 +25,6 @@
 ||edge.msn.com^
 ||events.data.microsoft.com^
 ||g.msn.com^
-||login.microsoftonline.com^
 ||nexus.officeapps.live.com^
 ||nexusrules.officeapps.live.com^
 ||oca.telemetry.microsoft.com^

--- a/Unifi_Allowlist.txt
+++ b/Unifi_Allowlist.txt
@@ -2,7 +2,7 @@
 ! Description: Allows connectivity for UniFi network management and related services.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-21
+! Last updated: 2025-06-25
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, etc.
 
 @@||unifi.ui.com^

--- a/Writing_AI_Allowlist.txt
+++ b/Writing_AI_Allowlist.txt
@@ -2,7 +2,7 @@
 ! Description: Allows popular AI writing assistants to access their services.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-06-21
+! Last updated: 2025-06-25
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, etc.
 
 @@||grammarly.com^


### PR DESCRIPTION
## Summary
- update blocklists to 2025-06-25
- add new Microsoft domains to Microsoft_Tracking_Blocklist.txt
- remove login.microsoftonline.com from Slimmed_Microsoft_Blocklist
- bump version to v1.3.0 in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685b5af55b6483239b51bb94884258e1