### PR TITLE
Add GE Appliance domains

### DIFF
--- a/Home_Automation_Allowlist.txt
+++ b/Home_Automation_Allowlist.txt
@@ -2,7 +2,7 @@
 ! Description: Allows connectivity for common smart home services.
 ! Homepage: https://github.com/talonric332/Piss-off-Microsoft
 ! License: CC0 / Public Domain
-! Last updated: 2025-07-10
+! Last updated: 2025-07-20
 ! Usage: Compatible with AdGuard Home, uBlock Origin, Pi-hole, etc.
 
 @@||api.ring.com^
@@ -25,3 +25,10 @@
 @@||homeassistant.io^
 @@||home-assistant.io^
 @@||smartthings.com^
+@@||geappliances.com^
+@@||geappliances.io^
+@@||smarthq.com^
+@@||smarthqhome.com^
+@@||smarthqservice.com^
+@@||smarthqsolutions.com^
+@@||smarthqpro.com^


### PR DESCRIPTION
## Summary
- update `Home_Automation_Allowlist.txt`
  - refresh last updated date
  - allow GE Appliances and SmartHQ domains

## Testing
- `apt-get update`
- `apt-get install -y ed`


------
https://chatgpt.com/codex/tasks/task_e_687c904f4b20832394f41ae388c73070