### PR TITLE
Block Bing domain

### DIFF
--- a/Advertising_Network_Blocklist.txt
+++ b/Advertising_Network_Blocklist.txt
@@ -83,6 +83,7 @@
 ||adnxs.com^
 ||msedge.net^
 ||edge-mqtt.microsoft.com^
+||bing.com^
 ||c.bing.com^
 ||rad.msn.com^
 ||assets.msn.com^


### PR DESCRIPTION
## Summary
- add bing.com to Advertising Network Blocklist to ensure Bing is blocked along with other Microsoft advertising hosts

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6466bf798832390fe49363754c265